### PR TITLE
Add alliance leader exclusive feature

### DIFF
--- a/routes/event_routes.py
+++ b/routes/event_routes.py
@@ -164,11 +164,11 @@ def delete_event(event_id):
         event_name = event.name
         
         # Get assignments before deletion to update counts
-        mvp_assignment = MVPAssignment.query.filter_by(event_id=event_id).first()
+        mvp_assignments = MVPAssignment.query.filter_by(event_id=event_id).all()
         winner_assignment = WinnerAssignment.query.filter_by(event_id=event_id).first()
         
-        # Update player MVP count if this event had an MVP
-        if mvp_assignment:
+        # Update player MVP counts if this event had MVPs
+        for mvp_assignment in mvp_assignments:
             player = mvp_assignment.player
             player.mvp_count = max(0, player.mvp_count - 1)
             # Remove current MVP status if this was the current MVP
@@ -241,10 +241,11 @@ def api_list_events():
         for event in events:
             event_dict = event.to_dict()
             
-            # Add MVP assignment info
-            mvp_assignment = MVPAssignment.query.filter_by(event_id=event.id).first()
-            if mvp_assignment:
-                event_dict['mvp_assignment'] = mvp_assignment.to_dict()
+            # Add ALL MVP assignment info (since events can be reused)
+            mvp_assignments = MVPAssignment.query.filter_by(event_id=event.id).order_by(MVPAssignment.assigned_at.desc()).all()
+            if mvp_assignments:
+                event_dict['mvp_assignments'] = [assignment.to_dict() for assignment in mvp_assignments]
+                event_dict['mvp_assignment'] = mvp_assignments[0].to_dict()  # Keep first for backward compatibility
             
             # Add winner assignment info
             winner_assignment = WinnerAssignment.query.filter_by(event_id=event.id).first()

--- a/routes/event_routes.py
+++ b/routes/event_routes.py
@@ -34,9 +34,13 @@ def list_events():
         # Get assignment data for each event
         events_data = []
         for event in events:
+            # Get all MVP assignments for this event (since events can be reused)
+            mvp_assignments = MVPAssignment.query.filter_by(event_id=event.id).order_by(MVPAssignment.assigned_at.desc()).all()
+            
             event_info = {
                 'event': event,
-                'mvp_assignment': MVPAssignment.query.filter_by(event_id=event.id).first(),
+                'mvp_assignments': mvp_assignments,
+                'mvp_assignment': mvp_assignments[0] if mvp_assignments else None,  # Keep first for backward compatibility
                 'winner_assignment': WinnerAssignment.query.filter_by(event_id=event.id).first()
             }
             events_data.append(event_info)
@@ -202,18 +206,22 @@ def view_event(event_id):
     
     Shows:
     - Event details
-    - MVP assignment (if any)
+    - All MVP assignments (since events can be reused)
     - Winner assignment (if any)
     - Event history/timeline
     """
     try:
         event = Event.query.get_or_404(event_id)
-        mvp_assignment = MVPAssignment.query.filter_by(event_id=event_id).first()
+        
+        # Get ALL MVP assignments for this event (since events can be reused)
+        mvp_assignments = MVPAssignment.query.filter_by(event_id=event_id).order_by(MVPAssignment.assigned_at.desc()).all()
+        
+        # Get winner assignment (still only one per event)
         winner_assignment = WinnerAssignment.query.filter_by(event_id=event_id).first()
         
         return render_template('events/view.html',
                              event=event,
-                             mvp_assignment=mvp_assignment,
+                             mvp_assignments=mvp_assignments,
                              winner_assignment=winner_assignment)
         
     except Exception as e:

--- a/routes/player_routes.py
+++ b/routes/player_routes.py
@@ -316,3 +316,37 @@ def api_rotation_status():
             'success': False,
             'error': str(e)
         }), 500
+
+@bp.route('/api/mvp-history/<int:player_id>')
+def api_mvp_history(player_id):
+    """API endpoint to get player's MVP history"""
+    try:
+        player = Player.query.get_or_404(player_id)
+        
+        # Get all MVP assignments for this player with event details
+        mvp_assignments = db.session.query(MVPAssignment, Event).join(
+            Event, MVPAssignment.event_id == Event.id
+        ).filter(
+            MVPAssignment.player_id == player_id
+        ).order_by(MVPAssignment.assigned_at.desc()).all()
+        
+        history = []
+        for assignment, event in mvp_assignments:
+            history.append({
+                'event_name': event.name,
+                'event_date': event.event_date.isoformat() if event.event_date else None,
+                'assigned_at': assignment.assigned_at.isoformat() if assignment.assigned_at else None,
+                'event_description': event.description
+            })
+        
+        return jsonify({
+            'success': True,
+            'player_name': player.name,
+            'mvp_count': player.mvp_count,
+            'history': history
+        })
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -251,9 +251,24 @@
                                     </td>
                                     <td>
                                         {% if event.has_mvp %}
-                                            <span class="badge bg-primary">
-                                                <i class="bi bi-award-fill me-1"></i>Назначен
-                                            </span>
+                                            {% if event.mvp_players %}
+                                                <div class="d-flex flex-wrap gap-1">
+                                                    {% for mvp_name in event.mvp_players %}
+                                                        <span class="badge bg-primary">
+                                                            <i class="bi bi-award-fill me-1"></i>{{ mvp_name }}
+                                                        </span>
+                                                    {% endfor %}
+                                                    {% if event.mvp_count > 1 %}
+                                                        <span class="badge bg-info">
+                                                            <i class="bi bi-plus me-1"></i>{{ event.mvp_count }}x
+                                                        </span>
+                                                    {% endif %}
+                                                </div>
+                                            {% else %}
+                                                <span class="badge bg-primary">
+                                                    <i class="bi bi-award-fill me-1"></i>Назначен
+                                                </span>
+                                            {% endif %}
                                         {% else %}
                                             <span class="badge bg-secondary">
                                                 <i class="bi bi-dash-circle me-1"></i>Ожидает

--- a/templates/events/list.html
+++ b/templates/events/list.html
@@ -54,10 +54,19 @@
                                         <small>{{ event.event_date.strftime('%Y-%m-%d %H:%M') if event.event_date }}</small>
                                     </td>
                                     <td>
-                                        {% if mvp %}
-                                            <span class="badge bg-primary">
-                                                <i class="bi bi-award-fill me-1"></i>{{ mvp.player.name }}
-                                            </span>
+                                        {% if event_info.mvp_assignments %}
+                                            <div class="d-flex flex-wrap gap-1">
+                                                {% for assignment in event_info.mvp_assignments %}
+                                                    <span class="badge bg-primary">
+                                                        <i class="bi bi-award-fill me-1"></i>{{ assignment.player.name }}
+                                                    </span>
+                                                {% endfor %}
+                                                {% if event_info.mvp_assignments|length > 1 %}
+                                                    <span class="badge bg-info">
+                                                        <i class="bi bi-plus me-1"></i>{{ event_info.mvp_assignments|length }}x
+                                                    </span>
+                                                {% endif %}
+                                            </div>
                                         {% else %}
                                             <span class="badge bg-secondary">
                                                 <i class="bi bi-dash-circle me-1"></i>Ожидает

--- a/templates/events/view.html
+++ b/templates/events/view.html
@@ -91,29 +91,61 @@
             </div>
             <div class="card-body">
                 <div class="row">
-                    <!-- MVP Assignment -->
+                    <!-- MVP Assignments -->
                     <div class="col-md-6 mb-3">
                         <div class="card h-100">
                             <div class="card-header bg-primary text-white">
                                 <h6 class="card-title mb-0">
-                                    <i class="bi bi-trophy me-1"></i>Игрок MVP
+                                    <i class="bi bi-trophy me-1"></i>Игроки MVP
+                                    {% if mvp_assignments %}
+                                        <span class="badge bg-light text-primary ms-2">{{ mvp_assignments|length }}</span>
+                                    {% endif %}
                                 </h6>
                             </div>
-                            <div class="card-body text-center">
-                                {% if mvp_assignment %}
-                                    <i class="bi bi-person-fill-check text-primary mb-2" style="font-size: 2rem;"></i>
-                                    <h5 class="text-primary">{{ mvp_assignment.player.name }}</h5>
-                                    <p class="text-muted mb-1">
-                                        Назначен: {{ mvp_assignment.assigned_at.strftime('%Y-%m-%d %H:%M') if mvp_assignment.assigned_at }}
-                                    </p>
-                                    <small class="text-muted">Количество MVP: {{ mvp_assignment.player.mvp_count }}</small>
+                            <div class="card-body">
+                                {% if mvp_assignments %}
+                                    <div class="text-center mb-3">
+                                        <i class="bi bi-person-fill-check text-primary mb-2" style="font-size: 2rem;"></i>
+                                        <h6 class="text-primary">История назначений MVP</h6>
+                                    </div>
+                                    
+                                    <div class="list-group list-group-flush">
+                                        {% for assignment in mvp_assignments %}
+                                        <div class="list-group-item px-0 py-2">
+                                            <div class="d-flex justify-content-between align-items-center">
+                                                <div>
+                                                    <h6 class="mb-1 text-primary">
+                                                        <i class="bi bi-trophy-fill text-warning me-2"></i>
+                                                        {{ assignment.player.name }}
+                                                    </h6>
+                                                    <small class="text-muted">
+                                                        Назначен: {{ assignment.assigned_at.strftime('%Y-%m-%d %H:%M') if assignment.assigned_at }}
+                                                    </small>
+                                                </div>
+                                                <div class="text-end">
+                                                    <small class="text-muted">
+                                                        MVP: {{ assignment.player.mvp_count }}x
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        {% endfor %}
+                                    </div>
+                                    
+                                    <div class="text-center mt-3">
+                                        <a href="{{ url_for('players.assign_mvp') }}" class="btn btn-primary btn-sm">
+                                            <i class="bi bi-award me-1"></i>Назначить еще MVP
+                                        </a>
+                                    </div>
                                 {% else %}
-                                    <i class="bi bi-question-circle text-muted mb-2" style="font-size: 2rem;"></i>
-                                    <h6 class="text-muted">MVP не назначен</h6>
-                                    <p class="text-muted">У этого события еще нет MVP.</p>
-                                    <a href="{{ url_for('players.assign_mvp') }}" class="btn btn-primary btn-sm">
-                                        <i class="bi bi-award me-1"></i>Назначить MVP
-                                    </a>
+                                    <div class="text-center">
+                                        <i class="bi bi-question-circle text-muted mb-2" style="font-size: 2rem;"></i>
+                                        <h6 class="text-muted">MVP не назначен</h6>
+                                        <p class="text-muted">У этого события еще нет MVP.</p>
+                                        <a href="{{ url_for('players.assign_mvp') }}" class="btn btn-primary btn-sm">
+                                            <i class="bi bi-award me-1"></i>Назначить MVP
+                                        </a>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>

--- a/templates/players/list.html
+++ b/templates/players/list.html
@@ -105,7 +105,14 @@
                                             {% else %}
                                                 <i class="bi bi-person-circle text-muted me-2"></i>
                                             {% endif %}
-                                            <strong>{{ player.name }}</strong>
+                                            <strong>
+                                                <a href="#" class="text-decoration-none player-name-link" 
+                                                   data-player-id="{{ player.id }}" 
+                                                   data-player-name="{{ player.name }}"
+                                                   title="Показать историю MVP">
+                                                    {{ player.name }}
+                                                </a>
+                                            </strong>
                                         </div>
                                     </td>
                                     <td>
@@ -318,6 +325,91 @@
         </div>
     </div>
 </div>
+
+<!-- MVP History Modal -->
+<div class="modal fade" id="mvpHistoryModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i class="bi bi-trophy me-2"></i>История MVP: <span id="historyPlayerName"></span>
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div id="historyLoading" class="text-center py-4">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Загрузка...</span>
+                    </div>
+                    <p class="mt-2">Загрузка истории MVP...</p>
+                </div>
+                
+                <div id="historyContent" style="display: none;">
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <div class="card bg-light">
+                                <div class="card-body text-center">
+                                    <h4 class="text-primary mb-0" id="totalMvpCount">0</h4>
+                                    <small class="text-muted">Всего наград MVP</small>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="card bg-light">
+                                <div class="card-body text-center">
+                                    <h4 class="text-success mb-0" id="totalEvents">0</h4>
+                                    <small class="text-muted">Участий в событиях</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <h6 class="mb-3">
+                        <i class="bi bi-list-ul me-2"></i>Детальная история
+                    </h6>
+                    
+                    <div id="historyList">
+                        <!-- History items will be populated here -->
+                    </div>
+                    
+                    <div id="noHistory" class="text-center text-muted py-4" style="display: none;">
+                        <i class="bi bi-trophy" style="font-size: 3rem;"></i>
+                        <h5 class="mt-3">Пока нет истории MVP</h5>
+                        <p>Этот игрок еще не получал награду MVP.</p>
+                    </div>
+                </div>
+                
+                <div id="historyError" class="alert alert-danger" style="display: none;">
+                    <i class="bi bi-exclamation-triangle me-2"></i>
+                    <span id="historyErrorMessage"></span>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Закрыть</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<style>
+.player-name-link {
+    color: inherit !important;
+    transition: color 0.2s ease;
+}
+
+.player-name-link:hover {
+    color: #0d6efd !important;
+    text-decoration: underline !important;
+}
+
+.player-name-link:focus {
+    color: #0d6efd !important;
+    text-decoration: underline !important;
+    outline: none;
+}
+</style>
 {% endblock %}
 
 {% block extra_js %}
@@ -366,5 +458,107 @@ setInterval(function() {
     // You can add AJAX call here to refresh rotation status
     console.log('Checking rotation status...');
 }, 30000);
+
+// MVP History Modal functionality
+document.addEventListener('DOMContentLoaded', function() {
+    // Add click event listeners to player name links
+    document.querySelectorAll('.player-name-link').forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            const playerId = this.getAttribute('data-player-id');
+            const playerName = this.getAttribute('data-player-name');
+            showMvpHistory(playerId, playerName);
+        });
+    });
+});
+
+function showMvpHistory(playerId, playerName) {
+    // Set player name in modal title
+    document.getElementById('historyPlayerName').textContent = playerName;
+    
+    // Show loading state
+    document.getElementById('historyLoading').style.display = 'block';
+    document.getElementById('historyContent').style.display = 'none';
+    document.getElementById('historyError').style.display = 'none';
+    
+    // Show modal
+    const modal = new bootstrap.Modal(document.getElementById('mvpHistoryModal'));
+    modal.show();
+    
+    // Fetch MVP history
+    fetch(`/players/api/mvp-history/${playerId}`)
+        .then(response => response.json())
+        .then(data => {
+            document.getElementById('historyLoading').style.display = 'none';
+            
+            if (data.success) {
+                displayMvpHistory(data);
+            } else {
+                showHistoryError(data.error || 'Не удалось загрузить историю MVP');
+            }
+        })
+        .catch(error => {
+            document.getElementById('historyLoading').style.display = 'none';
+            showHistoryError('Ошибка при загрузке истории MVP: ' + error.message);
+        });
+}
+
+function displayMvpHistory(data) {
+    const historyContent = document.getElementById('historyContent');
+    const historyList = document.getElementById('historyList');
+    const noHistory = document.getElementById('noHistory');
+    
+    // Update summary stats
+    document.getElementById('totalMvpCount').textContent = data.mvp_count;
+    document.getElementById('totalEvents').textContent = data.history.length;
+    
+    if (data.history.length === 0) {
+        historyContent.style.display = 'block';
+        noHistory.style.display = 'block';
+        historyList.innerHTML = '';
+    } else {
+        historyContent.style.display = 'block';
+        noHistory.style.display = 'none';
+        
+        // Generate history list
+        let historyHtml = '';
+        data.history.forEach(function(item, index) {
+            const eventDate = item.event_date ? new Date(item.event_date).toLocaleDateString('ru-RU') : 'Дата не указана';
+            const assignedDate = item.assigned_at ? new Date(item.assigned_at).toLocaleDateString('ru-RU') : 'Дата не указана';
+            
+            historyHtml += `
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <div class="row align-items-center">
+                            <div class="col-md-1 text-center">
+                                <span class="badge bg-primary rounded-pill">${index + 1}</span>
+                            </div>
+                            <div class="col-md-7">
+                                <h6 class="mb-1">
+                                    <i class="bi bi-trophy-fill text-warning me-2"></i>
+                                    ${item.event_name}
+                                </h6>
+                                ${item.event_description ? `<p class="text-muted mb-0 small">${item.event_description}</p>` : ''}
+                            </div>
+                            <div class="col-md-4 text-end">
+                                <div class="text-muted small">
+                                    <div><strong>Событие:</strong> ${eventDate}</div>
+                                    <div><strong>Назначен:</strong> ${assignedDate}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+        });
+        
+        historyList.innerHTML = historyHtml;
+    }
+}
+
+function showHistoryError(message) {
+    document.getElementById('historyErrorMessage').textContent = message;
+    document.getElementById('historyError').style.display = 'block';
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
Add a player MVP history modal and update event displays to show all MVP assignments, resolving the issue where only the first MVP was visible for reusable events.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ff06d2e-3d5c-4caf-ac4b-31f8ce3cacf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ff06d2e-3d5c-4caf-ac4b-31f8ce3cacf2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

